### PR TITLE
Add id for Action protocol

### DIFF
--- a/Sources/SwiftUIFlux/protocols/Action.swift
+++ b/Sources/SwiftUIFlux/protocols/Action.swift
@@ -8,4 +8,13 @@
 
 import Foundation
 
-public protocol Action { }
+public protocol Action {
+    var id: String {get set}
+}
+
+extension Action {
+    var id: String {
+      get { return "NOT DEFINED" }
+      set {}
+    }
+}


### PR DESCRIPTION
## Description
This MR is to add an optional `id` property to `Action` protocol

## Why
With `id` added, we don't need to run all cases in reducer, here is an example

// old
```swift
func appStateReducer(state: AppState, action: Action) -> AppState {
    var state = state
    state.nextRacesState = nextRacesStateReducer(state: state.nextRacesState, action: action)
    state.timestampSyncState = timestampSyncStateReducer(state: state.timestampSyncState, action: action)
    return state
}
```

// new
```swift
func appStateReducer(state: AppState, action: Action) -> AppState {
    var state = state
    switch action.id {
    case NextRacesActions.actionId:
        state.nextRacesState = nextRacesStateReducer(state: state.nextRacesState, action: action)
    case TimestampSyncActions.actionId:
        state.timestampSyncState = timestampSyncStateReducer(state: state.timestampSyncState, action: action)
    default:
        print("do nothing")
    }
    return state
}
```
