### PR TITLE
Allow to set custom DispatchQueue

### DIFF
--- a/Sources/SwiftUIFlux/Store.swift
+++ b/Sources/SwiftUIFlux/Store.swift
@@ -6,43 +6,56 @@
 //  Copyright © 2019 Thomas Ricouard. All rights reserved.
 //
 
+import Combine
 import Foundation
 import SwiftUI
-import Combine
 
-final public class Store<StoreState: FluxState>: ObservableObject {
+public final class Store<StoreState: FluxState>: ObservableObject {
     @Published public var state: StoreState
 
     private var dispatchFunction: DispatchFunction!
     private let reducer: Reducer<StoreState>
-    
-    public init(reducer: @escaping Reducer<StoreState>,
-                middleware: [Middleware<StoreState>] = [],
-                state: StoreState) {
+    private let dispatchQueue: DispatchQueue
+
+    public init(
+        reducer: @escaping Reducer<StoreState>,
+        middleware: [Middleware<StoreState>] = [],
+        state: StoreState,
+        dispatchQueue: DispatchQueue = .main
+    ) {
         self.reducer = reducer
         self.state = state
-        
+        self.dispatchQueue = dispatchQueue
+
         var middleware = middleware
         middleware.append(asyncActionsMiddleware)
-        self.dispatchFunction = middleware
+        dispatchFunction = middleware
             .reversed()
             .reduce(
                 { [unowned self] action in
-                    self._dispatch(action: action) },
+                    self._dispatchOnMainQueue(action: action)
+                },
                 { dispatchFunction, middleware in
                     let dispatch: (Action) -> Void = { [weak self] in self?.dispatch(action: $0) }
                     let getState = { [weak self] in self?.state }
                     return middleware(dispatch, getState)(dispatchFunction)
-            })
+                }
+            )
     }
 
     public func dispatch(action: Action) {
-        DispatchQueue.main.async {
+        dispatchQueue.async {
             self.dispatchFunction(action)
         }
     }
-    
+
     private func _dispatch(action: Action) {
         state = reducer(state, action)
+    }
+
+    private func _dispatchOnMainQueue(action: Action) {
+        DispatchQueue.main.async {
+            self._dispatch(action: action)
+        }
     }
 }


### PR DESCRIPTION
This change adds the possibility to set a custom `DispatchQueue` for the public `dispatch` method.

The internal `_dispatch` function will be called on the `.main` queue so that `ObservableObject`s `Publisher` will be triggered on `.main`. This is important for use with `SwiftUI`.